### PR TITLE
Feature: add configurable selection of vehicles on train as a target

### DIFF
--- a/src/viewmodels/vehicleViewModel.ts
+++ b/src/viewmodels/vehicleViewModel.ts
@@ -29,6 +29,7 @@ export class VehicleViewModel
 	readonly _rides = store<ParkRide[]>([]);
 	readonly _trains = compute(this._selectedRide, r => (r) ? r[0]._trains() : []);
 	readonly _vehicles = compute(this._selectedTrain, t => (t) ? t[0]._vehicles() : []);
+	readonly _lastVehicle = store<number>(0);
 
 	readonly _type = store<[RideType, number] | null>(null);
 	readonly _variants = compute(this._type, t => (t) ? t[0]._variants() : []);
@@ -55,16 +56,18 @@ export class VehicleViewModel
 	readonly _isUnpowered = compute(this._selectedVehicle, this._type, this._variant, v => !v || !v[0]._isPowered());
 	readonly _isPicking = store<boolean>(false);
 	readonly _isDragging = store<boolean>(false);
+	readonly _isSequence = store<boolean>(false);
 	readonly _isEditDisabled = compute(this._selectedVehicle, v => !v);
 	readonly _isSpinDisabled = compute(this._spinFrames, v => !v);
 	readonly _isPositionDisabled = compute(this._isMoving, this._isEditDisabled, (m, e) => m || e);
 	readonly _formatPosition = (pos: number): string => (this._isEditDisabled.get() ? "Not available" : pos.toString());
 	readonly _multiplierIndex = store<number>(0);
 	readonly _multiplier = compute(this._multiplierIndex, idx => (10 ** idx));
+	readonly _sequenceValue = store<number>(1);
 
 	readonly _copyFilters = store(CopyFilter.Default);
 	readonly _copyTargetOption = store<CopyOptions>(0);
-	readonly _copyTargets = compute(this._copyTargetOption, this._selectedVehicle, (o, v) => getTargets(o, this._selectedRide.get(), this._selectedTrain.get(), v));
+	readonly _copyTargets = compute(this._copyTargetOption, this._selectedVehicle, this._sequenceValue, this._lastVehicle, (o, v, s, l) => getTargets(o, this._selectedRide.get(), this._selectedTrain.get(), v, s, l ));
 	readonly _synchronizeTargets = store<boolean>(false);
 	readonly _clipboard = store<VehicleSettings | null>(null);
 

--- a/tests/services/vehicleCopier.tests.ts
+++ b/tests/services/vehicleCopier.tests.ts
@@ -32,7 +32,7 @@ const getTargetsMacro = test.macro((t, option: CopyOptions, trainIndex: number, 
 	const train = ride._trains()[trainIndex];
 	const vehicle = train._at(vehicleIndex);
 
-	const targets = getTargets(option, [ride, 25], [train, trainIndex], [vehicle, vehicleIndex]);
+	const targets = getTargets(option, [ride, 25], [train, trainIndex], [vehicle, vehicleIndex], 1, 1);
 
 	t.deepEqual(targets, expectedTargets);
 });


### PR DESCRIPTION
Messing around with a Carnaval Festival-esque ride, took me a long time to modify each other vehicle to a reverser bogey by hand:
![image](https://github.com/user-attachments/assets/919040dd-6739-4662-acad-3c41a1bfe624)

So that gave me the idea to add a feature where you can configure which vehicles on the train you want to modify.

https://github.com/user-attachments/assets/fe4c3d56-5945-4c05-a838-fafc433cf9e1


https://github.com/user-attachments/assets/d1f847ff-1d1a-40af-85f3-a6005f36ba19

Eventually I moved the option at the bottom of the "this train" options and renamed it to `Custom selection of vehicles on this train` to keep everything consistant and/or uniform.
![image](https://github.com/user-attachments/assets/46338fa7-dba9-4e4b-99aa-fd763a1c02bc)

Todo: add this feature for all the trains on a ride.